### PR TITLE
Feature/add support for fragments

### DIFF
--- a/secure_graphene/depth.py
+++ b/secure_graphene/depth.py
@@ -22,13 +22,10 @@ def measure_depth(selection_set, current_depth=1):
     return max_depth
 
 class DepthAnalysisBackend(GraphQLCoreBackend):
-    def __init__(self, max_depth, execute_params=None):
-        self.max_depth = max_depth 
-        if execute_params is None:
-            self.execute_params = {'executor': None}
-         else: 
-            self.execute_params = execute_params
-                   
+    def __init__(self, max_depth: int, executor: Optional[Any] = None):
+        super().__init__(executor=executor)
+        self.max_depth = max_depth
+
     def document_from_string(self, schema, document_string):
         document = super().document_from_string(schema, document_string)
         ast = document.document_ast

--- a/secure_graphene/depth.py
+++ b/secure_graphene/depth.py
@@ -1,37 +1,107 @@
-from graphql.backend.core import GraphQLCoreBackend
+from typing import Union, Optional, Any, Dict, List
 
-def measure_depth(selection_set, current_depth=1):
-    '''
+from graphql import GraphQLDocument, GraphQLSchema
+from graphql.backend.core import GraphQLCoreBackend
+from graphql.language.ast import (
+    Document,
+    FragmentDefinition,
+    OperationDefinition,
+    Node,
+    FragmentSpread,
+    Field,
+    InlineFragment,
+)
+
+
+class DepthLimitReached(Exception):
+    pass
+
+
+def get_fragments(definitions) -> Dict[str, FragmentDefinition]:
+    return {
+        definition.name.value: definition
+        for definition in definitions
+        if isinstance(definition, FragmentDefinition)
+    }
+
+
+def get_queries_and_mutations(definitions) -> List[OperationDefinition]:
+    return [
+        definition
+        for definition in definitions
+        if isinstance(definition, OperationDefinition)
+    ]
+
+
+def measure_depth(node: Node, fragments: Dict[str, FragmentDefinition]) -> int:
+    """
     A function which recursively measures the depth of a Graphene Query
-    
-    :type selection_set: SelectionSet 
-    :param selection_set: Graphql-core object used for query traversal/indexing  
-    
-    :type current_depth: int 
-    :param current_depth: The current depth of the query 
-    
-    :rtype: int 
-    :return: The max depth of the query  
-    '''
-    max_depth = current_depth
-    for field in selection_set.selections:
-        if field.selection_set:
-            new_depth = measure_depth(field.selection_set, current_depth=current_depth + 1)
-            if new_depth > max_depth:
-                max_depth = new_depth
-    return max_depth
+
+    :type node: Node
+    :param node: Graphql-core object used for query traversal/indexing
+
+    :type fragments: dict
+    :param fragments: The fragments of the query
+
+    :rtype: int
+    :return: The max depth of the node
+    """
+
+    if isinstance(node, FragmentSpread):
+        fragment = fragments.get(node.name.value)
+        return measure_depth(node=fragment, fragments=fragments)
+
+    elif isinstance(node, Field):
+        if node.name.value.lower() in ["__schema", "__introspection"]:
+            return 0
+
+        if not node.selection_set:
+            return 1
+
+        depths = []
+        for selection in node.selection_set.selections:
+            depth = measure_depth(node=selection, fragments=fragments)
+            depths.append(depth)
+        return 1 + max(depths)
+
+    elif (
+        isinstance(node, FragmentDefinition)
+        or isinstance(node, OperationDefinition)
+        or isinstance(node, InlineFragment)
+    ):
+        depths = []
+        for selection in node.selection_set.selections:
+            depth = measure_depth(node=selection, fragments=fragments)
+            depths.append(depth)
+        return max(depths)
+    else:
+        raise Exception("Unknown node")
+
+
+def check_max_depth(max_depth: int, document: Document):
+    fragments = get_fragments(document.definitions)
+    queries = get_queries_and_mutations(document.definitions)
+
+    for query in queries:
+        depth = measure_depth(query, fragments)
+        if depth > max_depth:
+            raise DepthLimitReached(
+                "Query is too deep - its depth is {} but the max depth is {}".format(
+                    depth, max_depth
+                )
+            )
+
 
 class DepthAnalysisBackend(GraphQLCoreBackend):
     def __init__(self, max_depth: int, executor: Optional[Any] = None):
         super().__init__(executor=executor)
         self.max_depth = max_depth
 
-    def document_from_string(self, schema, document_string):
+    def document_from_string(
+        self, schema: GraphQLSchema, document_string: Union[Document, str]
+    ) -> GraphQLDocument:
         document = super().document_from_string(schema, document_string)
-        ast = document.document_ast
-        for definition in ast.definitions:
-            depth = measure_depth(definition.selection_set)
-            if depth > self.max_depth: 
-                raise Exception('Query is too deep - its depth is {} but the max depth is {}'.format(depth, self.max_depth))
+
+        check_max_depth(max_depth=self.max_depth, document=document.document_ast)
 
         return document

--- a/tests/test_depth.py
+++ b/tests/test_depth.py
@@ -1,0 +1,490 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from graphql import GraphQLCoreBackend
+from graphql.language.ast import FragmentDefinition
+from graphene.test import Client
+from examples.starwars.schema import schema
+
+from secure_graphene.depth import (
+    measure_depth,
+    DepthAnalysisBackend,
+    DepthLimitReached,
+    get_fragments,
+    get_queries_and_mutations,
+)
+
+
+class GetFragmentsTest(unittest.TestCase):
+    def test_when_no_fragments_expect_empty_dict(self):
+        query = """            
+            query {
+              luke: human(id: "1000") {
+                name
+                friends {
+                  name
+                  friends {
+                    name
+                    friends {
+                      name 
+                    }
+                  }
+                }
+              }
+              leia: human(id: "1003") {
+                name
+                friends {
+                  name
+                  friends {
+                    name
+                  }
+                }
+              }
+            }
+        """
+        document = GraphQLCoreBackend().document_from_string(
+            schema=schema, document_string=query
+        )
+        definitions = document.document_ast.definitions
+
+        fragments = get_fragments(definitions=definitions)
+
+        expect = 0
+        result = len(fragments)
+
+        self.assertEqual(expect, result)
+
+    def test_when_two_fragments_expect_two_items_in_dict(self):
+        query = """
+            query {
+              hero {
+                ...nameFragment
+                ...friendsFragment
+              }
+            }
+
+            fragment nameFragment on Character {
+              name
+            }
+            fragment friendsFragment on Character {
+              friends {
+                name
+              }
+            }
+        """
+        document = GraphQLCoreBackend().document_from_string(
+            schema=schema, document_string=query
+        )
+        definitions = document.document_ast.definitions
+
+        fragments = get_fragments(definitions=definitions)
+
+        expect = 2
+        result = len(fragments)
+        expect_key = "nameFragment"
+        expect_class = FragmentDefinition
+        result_object = fragments.get(expect_key)
+
+        self.assertEqual(expect, result)
+        self.assertIsInstance(result_object, expect_class)
+
+
+class GetQueriesTest(unittest.TestCase):
+    def test_when_two_operation_definitions_expect_two_items(self):
+        query = """            
+            query {
+              luke: human(id: "1000") {
+                name
+              }
+            }            
+            query {
+              leia: human(id: "1003") {
+                name
+              }
+            }
+        """
+        document = GraphQLCoreBackend().document_from_string(
+            schema=schema, document_string=query
+        )
+        definitions = document.document_ast.definitions
+
+        queries = get_queries_and_mutations(definitions=definitions)
+
+        expect = 2
+        result = len(queries)
+
+        self.assertEqual(expect, result)
+
+    def test_when_two_fragments_expect_two_items_in_dict(self):
+        query = """
+            query {
+              hero {
+                ...nameFragment
+                ...friendsFragment
+              }
+            }
+
+            fragment nameFragment on Character {
+              name
+            }
+            fragment friendsFragment on Character {
+              friends {
+                name
+              }
+            }
+        """
+        document = GraphQLCoreBackend().document_from_string(
+            schema=schema, document_string=query
+        )
+        definitions = document.document_ast.definitions
+
+        fragments = get_fragments(definitions=definitions)
+
+        expect = 2
+        result = len(fragments)
+        expect_key = "nameFragment"
+        expect_object = FragmentDefinition
+        result_object = fragments.get(expect_key)
+
+        self.assertEqual(expect, result)
+        self.assertIsInstance(result_object, expect_object)
+
+
+class MeasureDepthTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = Client(schema)
+
+    def test_when_depth_is_5_expect_measure_5_depth(self):
+        query = """            
+            query {
+              luke: human(id: "1000") {
+                name
+                friends {
+                  name
+                  friends {
+                    name
+                    friends {
+                      name 
+                    }
+                  }
+                }
+              }
+              leia: human(id: "1003") {
+                name
+                friends {
+                  name
+                  friends {
+                    name
+                  }
+                }
+              }
+            }
+        """
+        document = GraphQLCoreBackend().document_from_string(
+            schema=schema, document_string=query
+        )
+        node = document.document_ast.definitions[0]
+
+        result_depth = measure_depth(node=node, fragments={})
+        expected_depth = 5
+
+        self.assertEqual(expected_depth, result_depth)
+
+    def test_when_depth_is_2_expect_measure_2_depth(self):
+        query = """
+            query {
+              hero {
+                name
+              }
+            }
+        """
+        document = GraphQLCoreBackend().document_from_string(
+            schema=schema, document_string=query
+        )
+        node = document.document_ast.definitions[0]
+
+        result_depth = measure_depth(node=node, fragments={})
+        expected_depth = 2
+
+        self.assertEqual(expected_depth, result_depth)
+
+    def test_when_introspection_expect_measure_0_depth(self):
+        query = """
+            query IntrospectionQuery {
+              __schema {
+                queryType {
+                  name
+                }
+                mutationType {
+                  name
+                }
+                subscriptionType {
+                  name
+                }
+                types {
+                  ...FullType
+                }
+                directives {
+                  name
+                  description
+                  locations
+                  args {
+                    ...InputValue
+                  }
+                }
+              }
+            }
+
+            fragment FullType on __Type {
+              kind
+              name
+              description
+              fields(includeDeprecated: true) {
+                name
+                description
+                args {
+                  ...InputValue
+                }
+                type {
+                  ...TypeRef
+                }
+                isDeprecated
+                deprecationReason
+              }
+              inputFields {
+                ...InputValue
+              }
+              interfaces {
+                ...TypeRef
+              }
+              enumValues(includeDeprecated: true) {
+                name
+                description
+                isDeprecated
+                deprecationReason
+              }
+              possibleTypes {
+                ...TypeRef
+              }
+            }
+
+            fragment InputValue on __InputValue {
+              name
+              description
+              type {
+                ...TypeRef
+              }
+              defaultValue
+            }
+
+            fragment TypeRef on __Type {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                    ofType {
+                      kind
+                      name
+                      ofType {
+                        kind
+                        name
+                        ofType {
+                          kind
+                          name
+                          ofType {
+                            kind
+                            name
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        """
+        document = GraphQLCoreBackend().document_from_string(
+            schema=schema, document_string=query
+        )
+        node = document.document_ast.definitions[0]
+
+        result_depth = measure_depth(node=node, fragments={})
+        expected_depth = 0
+
+        self.assertEqual(expected_depth, result_depth)
+
+    def test_when_introspection_and_query_expect_measure_2_depth(self):
+        query = """
+            query {
+              hero {
+                name
+              }
+            }
+            query IntrospectionQuery {
+              __schema {
+                queryType {
+                  name
+                }
+                mutationType {
+                  name
+                }
+                subscriptionType {
+                  name
+                }
+                types {
+                  ...FullType
+                }
+                directives {
+                  name
+                  description
+                  locations
+                  args {
+                    ...InputValue
+                  }
+                }
+              }
+            }
+
+            fragment FullType on __Type {
+              kind
+              name
+              description
+              fields(includeDeprecated: true) {
+                name
+                description
+                args {
+                  ...InputValue
+                }
+                type {
+                  ...TypeRef
+                }
+                isDeprecated
+                deprecationReason
+              }
+              inputFields {
+                ...InputValue
+              }
+              interfaces {
+                ...TypeRef
+              }
+              enumValues(includeDeprecated: true) {
+                name
+                description
+                isDeprecated
+                deprecationReason
+              }
+              possibleTypes {
+                ...TypeRef
+              }
+            }
+
+            fragment InputValue on __InputValue {
+              name
+              description
+              type {
+                ...TypeRef
+              }
+              defaultValue
+            }
+
+            fragment TypeRef on __Type {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                    ofType {
+                      kind
+                      name
+                      ofType {
+                        kind
+                        name
+                        ofType {
+                          kind
+                          name
+                          ofType {
+                            kind
+                            name
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        """
+        document = GraphQLCoreBackend().document_from_string(
+            schema=schema, document_string=query
+        )
+        node = document.document_ast.definitions[0]
+
+        result_depth = measure_depth(node=node, fragments={})
+        expected_depth = 2
+
+        self.assertEqual(expected_depth, result_depth)
+
+
+class DepthAnalysisBackendTest(unittest.TestCase):
+    @patch("secure_graphene.depth.measure_depth", MagicMock(return_value=3))
+    def test_when_max_depth_is_2_and_measure_3_expect_depth_limit_reached_exception(
+            self
+    ):
+        query = """
+            query {
+              __schema 
+              queryType {
+                name
+              }
+            }
+
+            query {
+              hero {
+                name
+                friends {
+                  name
+                }
+              }
+            }
+        """
+        backend = DepthAnalysisBackend(max_depth=2)
+
+        with self.assertRaises(DepthLimitReached):
+            backend.document_from_string(schema=schema, document_string=query)
+
+    @patch("secure_graphene.depth.measure_depth", MagicMock(return_value=3))
+    def test_when_max_depth_is_5_and_measure_3_expect_no_errors(self):
+        query = """
+            query {
+              hero {
+                ...heroNameAndFriends
+              }
+            }
+
+            fragment heroNameAndFriends on Character {
+              name
+              friends {
+                name
+              }
+            }
+        """
+        backend = DepthAnalysisBackend(max_depth=5)
+
+        document = backend.document_from_string(
+            schema=schema, document_string=query
+        )
+
+        self.assertIsNotNone(document)


### PR DESCRIPTION
Add support for queries that contain fragments and disable max depth for introspection queries.

I based my changes on the Javascript repository https://github.com/stems/graphql-depth-limit/blob/master/index.js